### PR TITLE
Fix toast listener setup

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -179,7 +179,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- update `useToast` effect dependencies so the listener is only registered once

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*
- `npm run build:dev` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843498b53d483258a75766fbfa8cf55